### PR TITLE
This PR adds support to m740dasm for the M50734 processor

### DIFF
--- a/docs/m50734.py
+++ b/docs/m50734.py
@@ -1,5 +1,5 @@
 # Special Function Registers for 50734 Group
-# Source: https://archive.org/details/bitsavers_mitsubishiishiSingleChip8BitMicrocomputers_54200624 Page 667-715
+# Source: https://archive.org/details/bitsavers_mitsubishiishiSingleChip8BitMicrocomputers_54200624
 
 sfrs = {
 

--- a/docs/m50734.py
+++ b/docs/m50734.py
@@ -1,0 +1,49 @@
+# Special Function Registers for 50734 Group
+# Source: https://archive.org/details/bitsavers_mitsubishiishiSingleChip8BitMicrocomputers_54200624 Page 667-715
+
+sfrs = {
+
+    0x00da: ('TXL',       'Timer X (lower byte)'),
+    0x00db: ('TXH',       'Timer X (higher byte)'),
+    0x00dc: ('PRE1',      'Prescaler 1'),
+    0x00dd: ('T1',        'Timer 1'),
+    0x00de: ('PRE2',      'Prescaler 2'),
+    0x00df: ('T2',        'Timer 2'),
+    0x00e0: ('PRE3',      'Prescaler 3'),
+    0x00e1: ('T3',        'Timer 3'),
+    0x00e2: ('HCNT',      'Horizontal counter'),
+    0x00e3: ('VCNT',      'Vertical counter'),
+    0x00e4: ('TSR',       'Transmit shift register'),
+    0x00e5: ('RBR',       'Receive buffer register'),
+    0x00e6: ('UCON',      'UART control register'),
+    0x00e7: ('USR',       'UART status register'),
+    0x00e8: ('SIO',       'Serial I/O register'),
+    0x00e9: ('ADCON',     'A-D control register'),
+    0x00ea: ('ADR',       'A-D register'),
+    0x00eb: ('P4IN',      'Port P4 input'),
+    0x00ec: ('PHASECNT',  'Vertical + Horizontal phase counter'),
+    0x00ed: ('P2P3FUNC',  'Port P2 P3 function register'),
+    0x00ee: ('P3',        'Port P3'),
+    0x00ef: ('P3DIR',     'Port P3 directional register'),
+    0x00f0: ('P2',        'Port P2'),
+    0x00f1: ('P2DIR',     'Port P2 directional register'),
+    0x00f2: ('P1IN',      'Port P1 latch input'),
+    0x00f3: ('P1',        'Port P1'),
+    0x00f4: ('P1DIR',     'Port P1 directional register'),
+    0x00f5: ('P0FUNC',    'Port P0 function register'),
+    0x00f6: ('P0',        'Port P0'),
+    0x00f7: ('P0DIR',     'Port P0 directional register'),
+    0x00f8: ('SMCONH',    'Stepper motor control register H'),
+    0x00f9: ('SMCONV',    'Stepper motor control register V'),
+    0x00fa: ('STBT',      'Strobe timer (Timer S)'),
+    0x00fb: ('BRGTB',     'Baud rate generator (Timer B)'),
+    0x00fc: ('WDT',       'Watchdog timer (Timer W)'),
+    0x00fd: ('ICON3',     'Interrupt control register 3'),
+    0x00fe: ('ICON2',     'Interrupt control register 2'),
+    0x00ff: ('ICON1',     'Interrupt control register 1'),
+
+}
+
+for address, (name, desc) in sfrs.items():
+    print("%04x: %s \t;%s" % (address, name, desc))
+    # print("%04x: (\"%s\", \t\"%s\")," % (address, name, desc))

--- a/m740dasm/devices.py
+++ b/m740dasm/devices.py
@@ -269,5 +269,5 @@ Devices["50734"] = {"vector_table":
 
     ]
 }
-# Add an "alias" for M37450
+# Add an "alias" for M50734
 Devices["M50734"] = Devices["50734"]

--- a/m740dasm/devices.py
+++ b/m740dasm/devices.py
@@ -206,3 +206,68 @@ Devices["M3886"] = {"vector_table":
     ]
 
 }
+# "50734" (e.g. M50734)
+# Source: https://archive.org/details/bitsavers_mitsubishiishiSingleChip8BitMicrocomputers_54200624
+Devices["50734"] = {"vector_table":
+    [ # Interrupt vector table - "50734 Group"
+        0xfff4, # TX, CNTR, or BRK
+        0xfff6, # HE or VE
+        0xfff8, # Timer1, Timer2, or Timer3
+        0xfffa, # RI or INT1
+        0xfffc, # INT2
+        0xfffe, # RESET
+    ],
+    "symbol_table":
+    [ # Symbol Table - "50734 Group"
+        # I/O
+        Symbol(0x00da, "TXL",       "Timer X (lower byte)"),
+        Symbol(0x00db, "TXH",       "Timer X (higher byte)"),
+        Symbol(0x00dc, "PRE1",      "Prescaler 1"),
+        Symbol(0x00dd, "T1",        "Timer 1"),
+        Symbol(0x00de, "PRE2",      "Prescaler 2"),
+        Symbol(0x00df, "T2",        "Timer 2"),
+        Symbol(0x00e0, "PRE3",      "Prescaler 3"),
+        Symbol(0x00e1, "T3",        "Timer 3"),
+        Symbol(0x00e2, "HCNT",      "Horizontal counter"),
+        Symbol(0x00e3, "VCNT",      "Vertical counter"),
+        Symbol(0x00e4, "TSR",       "Transmit shift register"),
+        Symbol(0x00e5, "RBR",       "Receive buffer register"),
+        Symbol(0x00e6, "UCON",      "UART control register"),
+        Symbol(0x00e7, "USR",       "UART status register"),
+        Symbol(0x00e8, "SIO",       "Serial I/O register"),
+        Symbol(0x00e9, "ADCON",     "A-D control register"),
+        Symbol(0x00ea, "ADR",       "A-D register"),
+        Symbol(0x00eb, "P4IN",      "Port P4 input"),
+        Symbol(0x00ec, "PHASECNT",  "Vertical + Horizontal phase counter"),
+        Symbol(0x00ed, "P2P3FUNC",  "Port P2 P3 function register"),
+        Symbol(0x00ee, "P3",        "Port P3"),
+        Symbol(0x00ef, "P3DIR",     "Port P3 directional register"),
+        Symbol(0x00f0, "P2",        "Port P2"),
+        Symbol(0x00f1, "P2DIR",     "Port P2 directional register"),
+        Symbol(0x00f2, "P1IN",      "Port P1 latch input"),
+        Symbol(0x00f3, "P1",        "Port P1"),
+        Symbol(0x00f4, "P1DIR",     "Port P1 directional register"),
+        Symbol(0x00f5, "P0FUNC",    "Port P0 function register"),
+        Symbol(0x00f6, "P0",        "Port P0"),
+        Symbol(0x00f7, "P0DIR",     "Port P0 directional register"),
+        Symbol(0x00f8, "SMCONH",    "Stepper motor control register H"),
+        Symbol(0x00f9, "SMCONV",    "Stepper motor control register V"),
+        Symbol(0x00fa, "STBT",      "Strobe timer (Timer S)"),
+        Symbol(0x00fb, "BRGTB",     "Baud rate generator (Timer B)"),
+        Symbol(0x00fc, "WDT",       "Watchdog timer (Timer W)"),
+        Symbol(0x00fd, "ICON3",     "Interrupt control register 3"),
+        Symbol(0x00fe, "ICON2",     "Interrupt control register 2"),
+        Symbol(0x00ff, "ICON1",     "Interrupt control register 1"),
+
+        # vectors
+        Symbol(0xfffe, "RESET",                 "Reset vector"),
+        Symbol(0xfffc, "INT_FFFC_INT2",         "INT2 (External interrupt 2)"),
+        Symbol(0xfffa, "INT_FFFA_RI_INT1",      "RI or INT1"),
+        Symbol(0xfff8, "INT_FFF8_T1T2T3",       "Timer1, Timer2, or Timer3"),
+        Symbol(0xfff6, "INT_FFF6_HEVE",         "HE or VE"),
+        Symbol(0xfff4, "INT_FFF4_TXCNTRBRK",    "TX, CNTR, or BRK"),
+
+    ]
+}
+# Add an "alias" for M37450
+Devices["M50734"] = Devices["50734"]


### PR DESCRIPTION
This PR includes two changes to the main repo to add support to m740dasm for the M50734 processor:

- Adds the interrupt vectors table, the special function registers symbols, and the vectors for this particular processor. These are added to devices.py.
- Adds a M50734.py file to the docs folder, which also contain a list of the special function registers.

The source of the key information in this PR comes from an extremely large PDF called Mitsubishi Semiconductors 1989 Single-Chip 8-bit microcomputers databook. It is available via archive.org: [Source here](https://archive.org/details/bitsavers_mitsubishiishiSingleChip8BitMicrocomputers_54200624) See pages 667-715.

I've tried to mimic the existing code, and touch as little as possible. The devices.py changes are simply appended to the bottom of the existing main copy. The docs file is just added to the folder. I tried to use a similar naming convention to other processors when possible, but YMMV.

**Testing**

- I ran pylint on both files, before and after, and the scores have not dropped.
- I rebuilt via a setup.py install and no errors were thrown.
- I tested the newly created m740dasm against one of the only ROM images I have. I don't have a great sample size here, but it appears to be functioning fine.
- I ran the end-to-end tests and they pass --- a diff between original and reassembled return nothing. I'm not changing anything, however, that I would expect to have any effect on this.
